### PR TITLE
Increase readWriteTimeout to 1 minute

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -263,7 +263,7 @@ type f struct{}
 
 var (
 	connectTimeout   = time.Duration(30 * time.Second) // timeout for http connection
-	readWriteTimeout = time.Duration(10 * time.Second) // timeout for http read/write
+	readWriteTimeout = time.Duration(60 * time.Second) // timeout for http read/write
 )
 
 // httpClient is the HTTP client used to make calls to Firebase with the default API


### PR DESCRIPTION
When running the migrator on Gaurav's production data this timeout was
hit often because he has ~40mb of data in firebase. Set the timeout to a
minute to avoid that case.